### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -8,6 +8,9 @@
 
 name: Java CI with Maven
 
+permissions:
+  contents: write
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/conorheffron/elastic-tester/security/code-scanning/1](https://github.com/conorheffron/elastic-tester/security/code-scanning/1)

To fix the problem, we should add a `permissions` block to the workflow file `.github/workflows/maven.yml`. The minimal permission required for mere checkout and build is `contents: read`. However, if the "Update dependency graph" step (using `advanced-security/maven-dependency-submission-action`) is present, it typically needs `contents: write`. We should explicitly define the permissions at the workflow level (right after the `name:` and `on:` fields, before `jobs:`) to apply least privilege to all jobs. No imports, library installs, or further code changes are necessary—only the YAML workflow file is changed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
